### PR TITLE
Fix Close column extraction

### DIFF
--- a/app.py
+++ b/app.py
@@ -14,7 +14,8 @@ def get_prices(period: str) -> pd.DataFrame:
     tickers_str = " ".join(TICKERS)
     data = yf.download(tickers_str, period=period, interval="1d", group_by="ticker", auto_adjust=False, threads=True)
     if isinstance(data.columns, pd.MultiIndex):
-        close = data["Close"]
+        # columns are (ticker, field) -> swap to (field, ticker) and pick Close
+        close = data.swaplevel(axis=1).xs("Close", level=0, axis=1)
     else:
         # single ticker case
         close = data[["Close"]]


### PR DESCRIPTION
## Summary
- revert earlier change that added an average daily return column
- correctly extract Close data when yfinance returns a ticker-first MultiIndex

## Testing
- `python -m py_compile app.py config.py`
