### PR TITLE
Show per-category charts with sparklines

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
   <title>Market Tracker</title>
+  <script src="https://cdn.plot.ly/plotly-2.26.0.min.js"></script>
 </head>
 <body class="p-4">
 <div class="container">
@@ -17,14 +18,20 @@
       {% endfor %}
     </select>
   </form>
-  <div class="mb-4">
-    {{ chart|safe }}
-  </div>
   {% for group, rows in tables.items() %}
   <h3 class="mt-4">{{ group }}</h3>
+  <div class="mb-3">
+    {{ charts[group]|safe }}
+  </div>
   <table class="table table-sm table-striped">
     <thead>
-      <tr><th>Ticker</th><th>Name</th><th class="text-end">Last Close</th><th class="text-end">% Change</th></tr>
+      <tr>
+        <th>Ticker</th>
+        <th>Name</th>
+        <th class="text-end">Last Close</th>
+        <th class="text-end">% Change</th>
+        <th>Trend</th>
+      </tr>
     </thead>
     <tbody>
       {% for row in rows %}
@@ -33,6 +40,7 @@
         <td>{{ row.name }}</td>
         <td class="text-end">{{ row.last }}</td>
         <td class="text-end">{{ row.change }}%</td>
+        <td>{{ row.spark|safe }}</td>
       </tr>
       {% endfor %}
     </tbody>


### PR DESCRIPTION
## Summary
- normalize each ticker and build per-category summary dataframes
- render a Plotly chart for every asset group and add inline sparklines in tables
- forward-fill prices on business days and remove unnecessary metrics

## Testing
- `python -m py_compile app.py config.py`