### PR TITLE
Fix interest rate display and remove avg return column

### DIFF
--- a/config.py
+++ b/config.py
@@ -17,7 +17,6 @@ CATEGORIES = {
         "^IRX": "US 3M T-Bill",
         "^TNX": "US 10Y Treasury",
         "^JGB10Y": "Japan 10Y Gov Bond",
-        "^SG10Y=RR": "Singapore 10Y Gov Bond",
         "^DE10Y=X": "Germany 10Y Bund",
     },
     "Currency": {

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,7 +32,6 @@
         <th class="text-end">Last Close</th>
         <th class="text-end">% Change</th>
         <th>Spark</th>
-        <th class="text-end">Avg Daily Return (30d)</th>
       </tr>
     </thead>
     <tbody>
@@ -43,12 +42,12 @@
         <td class="text-end">{{ row.last }}</td>
         <td class="text-end">{{ row.change }}%</td>
         <td>{{ row.spark|safe }}</td>
-        <td class="text-end">{% if row.avg is not none %}{{ row.avg }}%{% endif %}</td>
       </tr>
       {% endfor %}
     </tbody>
   </table>
   {% endfor %}
+  <footer class="text-muted small mt-5">Data sourced from Yahoo Finance</footer>
 </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- correctly handle tickers that only expose `Adj Close`
- drop 30-day average return calculation and column
- add Yahoo Finance attribution footer

## Testing
- `python -m py_compile app.py config.py`
