### PR TITLE
Add Render deployment files

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn --bind 0.0.0.0:$PORT app:app

--- a/README.md
+++ b/README.md
@@ -17,3 +17,15 @@ python app.py
 ```
 
 Open `http://localhost:5000` in your browser.
+
+## Deploying to Render
+
+This repository includes configuration files for deployment on
+[Render](https://render.com/). The service definition in `render.yaml`
+uses the free plan and runs the application with Gunicorn. Simply push
+this repository to a connected GitHub account and create a new Web
+Service in Render.
+
+Render will automatically install dependencies using
+`requirements.txt` and start the server with the command defined in the
+`Procfile` or `render.yaml`.

--- a/app.py
+++ b/app.py
@@ -149,4 +149,6 @@ def api_summary():
 
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    import os
+    port = int(os.environ.get("PORT", 5000))
+    app.run(host="0.0.0.0", port=port)

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,10 @@
+services:
+  - type: web
+    name: market-tracker
+    env: python
+    plan: free
+    buildCommand: pip install -r requirements.txt
+    startCommand: gunicorn --bind 0.0.0.0:$PORT app:app
+    envVars:
+      - key: FLASK_ENV
+        value: production


### PR DESCRIPTION
## Summary
- add `Procfile` to run the Flask app with gunicorn on Render
- add Render free tier config in `render.yaml`
- document deployment instructions
- ensure the app binds to the given port in production

## Testing
- `python -m py_compile app.py`